### PR TITLE
fix complex string (ex: "some:{$value}") parsing

### DIFF
--- a/src/QA/SoftMocks.php
+++ b/src/QA/SoftMocks.php
@@ -315,6 +315,8 @@ class SoftMocksPrinter extends \PhpParser\PrettyPrinter\Standard
         foreach ($encapsList as $element) {
             if (is_string($element)) {
                 $return .= addcslashes($element, "\n\r\t\f\v$" . $quote . "\\");
+            } elseif ($element instanceof \PhpParser\Node\Scalar) {
+                $return .= addcslashes($element->value, "\n\r\t\f\v$" . $quote . "\\");
             } else {
                 $return .= '{' . trim($this->p($element)) . '}';
             }


### PR DESCRIPTION
test case:

```
$ git status -s
 M example/common.php
```

```
$ git diff
diff --git a/example/common.php b/example/common.php
index 42b3c83..233ce37 100644
--- a/example/common.php
+++ b/example/common.php
@@ -18,5 +18,10 @@ class Example {
     {
         return self::DYNAMIC_DO_SMTH_RESULT;
     }
+
+    public function fatal() {
+        $b = '/';
+        $str = "a:{$b}";
+    }
 }
```

```
$ php example/run_me.php 
PHP Fatal error:  Uncaught Error: Call to undefined method QA\SoftMocksPrinter::pScalar_EncapsedStringPart() in /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php:94
Stack trace:
#0 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(319): QA\SoftMocksPrinter->p(Object(PhpParser\Node\Scalar\EncapsedStringPart))
#1 /home/axp/work/php/soft-mocks/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php(91): QA\SoftMocksPrinter->pEncapsList(Array, '"')
#2 /home/axp/work/php/soft-mocks/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(235): PhpParser\PrettyPrinter\Standard->pScalar_Encapsed(Object(PhpParser\Node\Scalar\Encapsed))
#3 /home/axp/work/php/soft-mocks/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinterAbstract.php(199): PhpParser\PrettyPrinterAbstract->pPrec(Object(PhpParser\Node\Scalar\Encapsed), 160, 1, 1)
#4 /home/axp/work/php/soft-mocks/vendor/nikic/php-parser/lib/PhpParser/PrettyPrinter/Standard.php(111): PhpParser\PrettyPrinterAbstract->pInfixOp('Expr_Assign', Object(PhpParser\Node\Expr\Variabl in /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php on line 94
```
