### PR TITLE
fix func_get_args() mock bug (php7 related) when one of function's ar…

### DIFF
--- a/src/QA/SoftMocks.php
+++ b/src/QA/SoftMocks.php
@@ -1715,13 +1715,13 @@ class SoftMocksTraverser extends \PhpParser\NodeVisitorAbstract
 
         $body_stmts = [
             new \PhpParser\Node\Expr\Assign(
+                new \PhpParser\Node\Expr\Variable("mm_func_args"),
+                new \PhpParser\Node\Expr\FuncCall(new \PhpParser\Node\Name("func_get_args"))
+            ),
+            new \PhpParser\Node\Expr\Assign(
                 new \PhpParser\Node\Expr\Variable("params"),
                 new \PhpParser\Node\Expr\Array_($params_arr)
             ),
-            new \PhpParser\Node\Expr\Assign(
-                new \PhpParser\Node\Expr\Variable("mm_func_args"),
-                new \PhpParser\Node\Expr\FuncCall(new \PhpParser\Node\Name("func_get_args"))
-            )
         ];
 
         // generators cannot return values,


### PR DESCRIPTION
As you know, in php7 behaviour of func_get_args() changed: now it returns current variables values instead of initial ones.

Currently mock code generated by SoftMocks looks like that:

```
if (\QA\SoftMocks::isMocked(Example::class, static::class, __FUNCTION__)) {
    $params = array();
    $mm_func_args = func_get_args();
    return eval(\QA\SoftMocks::getMockCode(Example::class, static::class, __FUNCTION__));
}
```

which means if one of method's arguments is called "params", variable $mm_func_args will contain wrong value:

```
public function query($q, $params = array()) {
    if (\QA\SoftMocks::isMocked(Example::class, static::class, __FUNCTION__)) {
        $params = array($q, $params);
        $mm_func_args = func_get_args();
        return eval(\QA\SoftMocks::getMockCode(Example::class, static::class, __FUNCTION__));
    }
    ...
```

calling func_get_args() before modifying/assigning any local variable solves this issue:

```
public function query($q, $params = array()) {
    if (\QA\SoftMocks::isMocked(Example::class, static::class, __FUNCTION__)) {
        $mm_func_args = func_get_args();
        $params = array($q, $params);
        return eval(\QA\SoftMocks::getMockCode(Example::class, static::class, __FUNCTION__));
    }
    ...
```
