### PR TITLE
fix parsing declare() without body. ex: "declare(ticks=1);"

### DIFF
--- a/src/QA/SoftMocks.php
+++ b/src/QA/SoftMocks.php
@@ -152,8 +152,11 @@ class SoftMocksPrinter extends \PhpParser\PrettyPrinter\Standard
 
     public function pStmt_Declare(\PhpParser\Node\Stmt\Declare_ $node)
     {
-        return 'declare (' . $this->pCommaSeparated($node->declares) . ') {'
-            . $this->pStmts($node->stmts) . '}';
+        $declare = 'declare (' . $this->pCommaSeparated($node->declares);
+        if (!$node->stmts) {
+            return $declare . ');';
+        }
+        return $declare . ') {' . $this->pStmts($node->stmts) . '}';
     }
 
     public function pStmt_If(\PhpParser\Node\Stmt\If_ $node)


### PR DESCRIPTION
There is fatal when parsing declare() without body.

```
diff --git a/example/common.php b/example/common.php
index 42b3c83..33e5ed7 100644
--- a/example/common.php
+++ b/example/common.php
@@ -16,6 +16,7 @@ class Example {

     public function doSmthDynamic()
     {
+        declare(ticks = 1);
         return self::DYNAMIC_DO_SMTH_RESULT;
     }
 }
```

```
$ php example/run_me.php 
PHP Fatal error:  Uncaught TypeError: Argument 1 passed to QA\SoftMocksPrinter::pStmts() must be of the type array, null given, called in /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php on line 156 and defined in /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php:45
Stack trace:
#0 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(156): QA\SoftMocksPrinter->pStmts(NULL)
#1 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(94): QA\SoftMocksPrinter->pStmt_Declare(Object(PhpParser\Node\Stmt\Declare_))
#2 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(63): QA\SoftMocksPrinter->p(Object(PhpParser\Node\Stmt\Declare_))
#3 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(142): QA\SoftMocksPrinter->pStmts(Array)
#4 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(94): QA\SoftMocksPrinter->pStmt_ClassMethod(Object(PhpParser\Node\Stmt\ClassMethod))
#5 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(63): QA\SoftMocksPrinter->p(Object(PhpParser\Node\Stmt\ClassMethod))
#6 /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php(30 in /home/axp/work/php/soft-mocks/src/QA/SoftMocks.php on line 45
```
