### PR TITLE
Compatibility with php-parser 2.1

### DIFF
--- a/src/QA/SoftMocks.php
+++ b/src/QA/SoftMocks.php
@@ -323,6 +323,17 @@ class SoftMocksPrinter extends \PhpParser\PrettyPrinter\Standard
 
         return $return;
     }
+
+    protected function pComments(array $comments)
+    {
+        $comments = parent::pComments($comments);
+
+        if ($comments && "\n" !== substr($comments, -1, 0)) {
+            $comments .= "\n";
+        }
+
+        return $comments;
+    }
 }
 
 class SoftMocks


### PR DESCRIPTION
If your upgrade to latest php-parser 2.1, then softmocks wrongly prints one-line comments:
`//        return;}`
instead of

```
//        return;
}
```

This caused by this change https://github.com/nikic/PHP-Parser/commit/5a6e7dd452632b88a5d4f2e5c96f348a2c1e3215 and because SoftMocks copy-paste-and-edit pStmts function.

This PR fix this with minimal effors - just force newline at the end of non empty comment.
