### PR TITLE
Fix warning 'PHP Warning:  array_key_exists() expects exactly 2 parameters, 1 given in src/QA/SoftMocks.php on line 991'

### DIFF
--- a/src/QA/SoftMocks.php
+++ b/src/QA/SoftMocks.php
@@ -988,7 +988,7 @@ class SoftMocks
             return self::$constant_mocks[$const];
         }
 
-        if (array_key_exists(self::$removed_constants)) {
+        if (array_key_exists($const, self::$removed_constants)) {
             trigger_error('Trying to access removed constant ' . $const . ', assuming "' . $const . '"');
             return $const;
         }


### PR DESCRIPTION
When I run `php example/run_me.php`, then I get next:

``` sh
....
PHP Warning:  array_key_exists() expects exactly 2 parameters, 1 given in /home/mougrim/Private/development/badoo/soft-mocks/src/QA/SoftMocks.php on line 991
...
```
