### PR TITLE
Fix error "PHP Fatal error:  Class 'Symfony\Polyfill\Php70\Php70' not found"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SoftMocks v1 Change Log
 
+## master
+
+There are next changes:
+
+- error "PHP Fatal error:  Class 'Symfony\Polyfill\Php70\Php70' not found" was fixed.
+
 ## v1.3.0
 
 There are next changes:

--- a/patches/phpunit4.x/phpunit
+++ b/patches/phpunit4.x/phpunit
@@ -85,6 +85,7 @@ if ($softMocksPath) {
             '/vendor/phpunit/' => '/vendor/phpunit/',
             '/vendor/sebastian/diff/' => '/vendor/sebastian/diff/',
             '/vendor/nikic/php-parser/' => '/vendor/nikic/php-parser/',
+            '/vendor/symfony/polyfill' => '/vendor/symfony/polyfill',
         )
     );
     \Badoo\SoftMocks::init();

--- a/patches/phpunit4.x/phpunit_phpunit.patch
+++ b/patches/phpunit4.x/phpunit_phpunit.patch
@@ -1,5 +1,5 @@
 diff --git a/phpunit b/phpunit
-index 539b842..ee60f79 100755
+index 539b842..80f9999 100755
 --- a/phpunit
 +++ b/phpunit
 @@ -27,9 +27,10 @@ if (!ini_get('date.timezone')) {
@@ -23,7 +23,7 @@ index 539b842..ee60f79 100755
      fwrite(STDERR,
          'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
          '    composer install' . PHP_EOL . PHP_EOL .
-@@ -47,6 +48,56 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+@@ -47,6 +48,57 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
      die(1);
  }
 
@@ -65,6 +65,7 @@ index 539b842..ee60f79 100755
 +            '/vendor/phpunit/' => '/vendor/phpunit/',
 +            '/vendor/sebastian/diff/' => '/vendor/sebastian/diff/',
 +            '/vendor/nikic/php-parser/' => '/vendor/nikic/php-parser/',
++            '/vendor/symfony/polyfill' => '/vendor/symfony/polyfill',
 +        )
 +    );
 +    \Badoo\SoftMocks::init();

--- a/patches/phpunit5.x/phpunit
+++ b/patches/phpunit5.x/phpunit
@@ -85,6 +85,7 @@ if ($softMocksPath) {
             '/vendor/phpunit/' => '/vendor/phpunit/',
             '/vendor/sebastian/diff/' => '/vendor/sebastian/diff/',
             '/vendor/nikic/php-parser/' => '/vendor/nikic/php-parser/',
+            '/vendor/symfony/polyfill' => '/vendor/symfony/polyfill',
         )
     );
     \Badoo\SoftMocks::init();

--- a/patches/phpunit5.x/phpunit_phpunit.patch
+++ b/patches/phpunit5.x/phpunit_phpunit.patch
@@ -1,5 +1,5 @@
 diff --git a/phpunit b/phpunit
-index f288633..1ef2c30 100755
+index f288633..42eb6a3 100755
 --- a/phpunit
 +++ b/phpunit
 @@ -27,9 +27,10 @@ if (!ini_get('date.timezone')) {
@@ -23,7 +23,7 @@ index f288633..1ef2c30 100755
      fwrite(STDERR,
          'You need to set up the project dependencies using Composer:' . PHP_EOL . PHP_EOL .
          '    composer install' . PHP_EOL . PHP_EOL .
-@@ -47,6 +48,56 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+@@ -47,6 +48,57 @@ if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
      die(1);
  }
  
@@ -65,6 +65,7 @@ index f288633..1ef2c30 100755
 +            '/vendor/phpunit/' => '/vendor/phpunit/',
 +            '/vendor/sebastian/diff/' => '/vendor/sebastian/diff/',
 +            '/vendor/nikic/php-parser/' => '/vendor/nikic/php-parser/',
++            '/vendor/symfony/polyfill' => '/vendor/symfony/polyfill',
 +        )
 +    );
 +    \Badoo\SoftMocks::init();


### PR DESCRIPTION
Next error was fixed:
```
PHP Fatal error:  Class 'Symfony\Polyfill\Php70\Php70' not found in /tmp/mocks/5.6.31-6+ubuntu16.04.1+deb.sury.org+13.0.6308df92345480a99624870615aa303c8/d0/bootstrap.php_d0fedfab546d7ac0a2564106020d46aa.php on line 25
PHP Stack trace:
PHP   1. {main}() vendor/phpunit/phpunit/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() vendor/phpunit/phpunit/phpunit:104
PHP   3. PHPUnit_TextUI_Command->run() vendor/phpunit/phpunit/src/TextUI/Command.php:116
PHP   4. PHPUnit_TextUI_Command->handleArguments() vendor/phpunit/phpunit/src/TextUI/Command.php:127
PHP   5. PHPUnit_TextUI_Command->handleBootstrap() vendor/phpunit/phpunit/src/TextUI/Command.php:739
PHP   6. PHPUnit_Util_Fileloader::checkAndLoad() vendor/phpunit/phpunit/src/TextUI/Command.php:914
PHP   7. PHPUnit_Util_Fileloader::load() vendor/phpunit/phpunit/src/Util/Fileloader.php:70
PHP   8. Badoo\SoftMocks::rewrite() vendor/phpunit/phpunit/src/Util/Fileloader.php:87
PHP   9. Badoo\SoftMocks::doRewrite() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:783
PHP  10. Badoo\SoftMocks::createRewrittenFile() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:851
PHP  11. Badoo\SoftMocks::rewriteContents() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:876
PHP  12. PhpParser\Parser\Multiple->parse() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:1193
PHP  13. PhpParser\Parser\Multiple->tryParse() vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:31
PHP  14. PhpParser\ParserAbstract->parse() vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:50
PHP  15. PhpParser\Lexer\Emulative->startLexing() vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:147
PHP  16. PhpParser\Lexer->startLexing() vendor/nikic/php-parser/lib/PhpParser/Lexer/Emulative.php:57
PHP  17. PhpParser\Lexer->resetErrors() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:74
PHP  18. error_clear_last() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:85
PHP  19. spl_autoload_call() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:25
PHP  20. Composer\Autoload\ClassLoader->loadClass() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:25
PHP  21. Badoo\SoftMocks::callFunction() /tmp/mocks/5.6.31-6+ubuntu16.04.1+deb.sury.org+13.0.6308df92345480a99624870615aa303c8/a5/ClassLoader.php_a5c645bd9cc7806c6b3a0dfd257d65ab.php:322
PHP  22. call_user_func_array:{vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:1094}() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:1094
PHP  23. Composer\Autoload\includeFile() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:1094
PHP  24. Badoo\SoftMocks::rewrite() /tmp/mocks/5.6.31-6+ubuntu16.04.1+deb.sury.org+13.0.6308df92345480a99624870615aa303c8/a5/ClassLoader.php_a5c645bd9cc7806c6b3a0dfd257d65ab.php:444
PHP  25. Badoo\SoftMocks::doRewrite() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:783
PHP  26. Badoo\SoftMocks::createRewrittenFile() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:851
PHP  27. Badoo\SoftMocks::rewriteContents() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:876
PHP  28. PhpParser\Parser\Multiple->parse() vendor/badoo/soft-mocks/src/Badoo/SoftMocks.php:1193
PHP  29. PhpParser\Parser\Multiple->tryParse() vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:31
PHP  30. PhpParser\ParserAbstract->parse() vendor/nikic/php-parser/lib/PhpParser/Parser/Multiple.php:50
PHP  31. PhpParser\Lexer\Emulative->startLexing() vendor/nikic/php-parser/lib/PhpParser/ParserAbstract.php:147
PHP  32. PhpParser\Lexer->startLexing() vendor/nikic/php-parser/lib/PhpParser/Lexer/Emulative.php:57
PHP  33. PhpParser\Lexer->resetErrors() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:74
PHP  34. error_clear_last() vendor/nikic/php-parser/lib/PhpParser/Lexer.php:85
```