### PR TITLE
Use path in project for cached files path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # SoftMocks v1 Change Log
 
+## master
+
+There are next changes:
+
+- use path in project for cached files path.
+
 ## v1.3.0
 
 There are next changes:

--- a/src/Badoo/SoftMocks.php
+++ b/src/Badoo/SoftMocks.php
@@ -389,6 +389,7 @@ class SoftMocks
 
     const LANG_CONSTRUCT_EXIT = 'exit';
 
+    private static $project_path;
     private static $rewrite_internal = false;
     private static $mocks_cache_path = "/tmp/mocks/";
     private static $ignore_sub_paths = [
@@ -547,6 +548,29 @@ class SoftMocks
 
         self::ignoreFiles(get_included_files());
         self::injectIntoPhpunit();
+        self::initProjectPath();
+    }
+
+    protected static function initProjectPath()
+    {
+        $lib_path = dirname(dirname(__DIR__));
+        $vendor_path = dirname(dirname($lib_path));
+        if (basename($vendor_path) === 'vendor') {
+            self::$project_path = dirname($vendor_path);
+            return;
+        }
+        self::$project_path = $lib_path;
+    }
+
+    public static function setProjectPath($project_path)
+    {
+        if (!empty($project_path)) {
+            self::$project_path = rtrim($project_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        }
+
+        if (!is_dir(self::$project_path)) {
+            throw new \RuntimeException("Project path isn't exists");
+        }
     }
 
     /**
@@ -844,8 +868,17 @@ class SoftMocks
             }
 
             $md5 = md5($clean_filepath . ':' . $md5_file);
+            if (self::$project_path && strpos($file, self::$project_path) === 0) {
+                $file_in_project = substr($file, strlen(self::$project_path));
+            } else {
+                $file_in_project = basename($file);
+            }
 
-            $target_file = self::$mocks_cache_path . self::getVersion() . DIRECTORY_SEPARATOR . mb_orig_substr($md5, 0, 2) . DIRECTORY_SEPARATOR . basename($file) . "_" . $md5 . ".php";
+            $target_file = self::$mocks_cache_path . self::getVersion() . DIRECTORY_SEPARATOR . $file_in_project . "_" . $md5 . ".php";
+            $target_dir = dirname($target_file);
+            if (!@mkdir($target_dir, 0777, true) && !is_dir($target_dir)) {
+                throw new \RuntimeException("Can't create {$target_dir}");
+            }
             if (!file_exists($target_file)) {
                 $old_umask = umask(0);
                 self::createRewrittenFile($file, $target_file);


### PR DESCRIPTION
File path was added for cached mocked files: 
for example for `vendor/autoload.php` using
`/tmp/mocks/7.0.24-1+ubuntu16.04.1+deb.sury.org+13.0.669e09b24c739eaf71c7be25afa1c558f/`**vendor**`/autoload.php_5981b2021c0e449c7c5b8f0d7cbc704a.php`
instead of
`/tmp/mocks/7.0.24-1+ubuntu16.04.1+deb.sury.org+13.0.6308df92345480a99624870615aa303c8/59/autoload.php_5981b2021c0e449c7c5b8f0d7cbc704a.php`