### PR TITLE
Open cache files path getter

### DIFF
--- a/src/Badoo/SoftMocks.php
+++ b/src/Badoo/SoftMocks.php
@@ -1040,7 +1040,7 @@ class SoftMocks
         return md5($clean_filepath . ':' . $md5_file);
     }
 
-    private static function getRewrittentFilePathPrefix()
+    public static function getRewrittentFilePathPrefix()
     {
         return self::$mocks_cache_path . self::getMocksDirVersion();
     }


### PR DESCRIPTION
Sometimes it's needed to obtain actual path to soft-mock cache. 
I.e. when we add support to IDE, we need to understand what path is exactly rewritten