### PR TITLE
Using php-7.4 version instead

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os: linux
 dist: trusty
 
 php:
-  - 7.4snapshot
+  - 7.4
   - 7.3
   - 7.2
   - 7.1


### PR DESCRIPTION
# Changed log

- Since the `php-7.4` version is available on Travis CI build, it should use the `php-7.4` version instead.